### PR TITLE
Fix: lists of links were all using the same URL unintentionally

### DIFF
--- a/templates/content/node--ubc-project--full.html.twig
+++ b/templates/content/node--ubc-project--full.html.twig
@@ -130,7 +130,7 @@
     {% if not (node.field_project_researchers.isEmpty == true) and content.field_project_researchers is defined %}
       <h3 class="h5">Researchers</h3>
       <p>{%- for tag in content.field_project_researchers['#items'] -%}
-        <a href="{{- path('entity.node.canonical', {'node':  node.field_project_researchers.entity.id}) -}}">{{- tag.entity.title.value -}}</a>
+        <a href="{{- path('entity.node.canonical', {'node':  tag.entity.nid.value}) -}}">{{- tag.entity.title.value -}}</a>
         {%- if loop.last == false -%},&nbsp;{%- endif -%}
       {%- endfor -%}
     {% endif %}</p>


### PR DESCRIPTION
e.g. If a site had 

_Link1_, _Link2_, _Link3_

Clicking on any of the links would navigate to wherever _Link1_ goes.